### PR TITLE
fix: exception in Composite.apply/1 with module name

### DIFF
--- a/lib/composite.ex
+++ b/lib/composite.ex
@@ -389,7 +389,10 @@ defmodule Composite do
   if Code.ensure_loaded?(Ecto.Queryable) do
     defimpl Ecto.Queryable do
       def to_query(composite) do
-        Composite.apply(composite)
+        case Composite.apply(composite) do
+          %Ecto.Query{} = query -> query
+          other -> Ecto.Queryable.to_query(other)
+        end
       end
     end
   end


### PR DESCRIPTION
This fix resolves the issue when passing a module name as queryable:

```
App.Accounts.User
|> Composite.new(%{})
|> Composite.param(:name, &where(&1, name: ^&2))
|> App.Repo.aggregate(:count)

** (BadMapError) expected a map, got: _____
    (ecto 3.7.2) lib/ecto/repo/queryable.ex:510: Ecto.Repo.Queryable.prepare_for_aggregate/1
    (ecto 3.7.2) lib/ecto/repo/queryable.ex:475: Ecto.Repo.Queryable.query_for_aggregate/2
    (ecto 3.7.2) lib/ecto/repo/queryable.ex:112: Ecto.Repo.Queryable.aggregate/4
```
