### PR TITLE
feat: check passed params are valid params

### DIFF
--- a/lib/composite.ex
+++ b/lib/composite.ex
@@ -240,6 +240,7 @@ defmodule Composite do
       composite
       |> set_once!(:input_query, input_query)
       |> set_once!(:params, params)
+      |> ensure_params_are_valid()
 
     {query, loaded_deps} =
       load_dependencies(
@@ -385,6 +386,19 @@ defmodule Composite do
       end)
 
     {query, MapSet.union(loaded_deps, deps_to_load)}
+  end
+
+  defp ensure_params_are_valid(composite) do
+    diff =
+      MapSet.difference(
+        MapSet.new(Map.keys(composite.params)),
+        MapSet.new(composite.param_definitions |> Enum.map(&elem(&1, 0)) |> List.flatten())
+      )
+
+    case MapSet.size(diff) do
+      0 -> composite
+      _ -> raise ArgumentError, "Unknown params: #{inspect(MapSet.to_list(diff))}"
+    end
   end
 
   if Code.ensure_loaded?(Ecto.Queryable) do


### PR DESCRIPTION
### Proposal:
Validate that the passed params by the caller are actually defined in the param definitions of the composite object.

### Current behavior:

Calling the following function:
```elixir
User
|> from(as: :user)
|> Composite.new(%{email: ["ABC", "def"]})
|> Composite.param(:emails, &filter_by_emails/2)
|> Composite.apply()
|> Repo.all()
```

Returns all the available users in the DB without any warning because the param is defined as `:emails` instead of `:email`.

### After the change 

Calling the same function as before gives:
```elixir
** (ArgumentError) Unknown params: [:email]
    (composite 0.4.3) lib/composite.ex:403: Composite.ensure_params_are_valid/1
    (composite 0.4.3) lib/composite.ex:243: Composite.apply/3
```
