### PR TITLE
Add option strict

### DIFF
--- a/lib/composite.ex
+++ b/lib/composite.ex
@@ -26,7 +26,8 @@ defmodule Composite do
             dep_definitions: %{},
             params: nil,
             input_query: nil,
-            required_deps: []
+            required_deps: [],
+            strict: false
 
   @type dependency_name :: atom()
   @type dependencies ::
@@ -70,6 +71,11 @@ defmodule Composite do
       |> where(active: true)
       |> Composite.apply(composite, params)
       |> Repo.all()
+
+  ### Options
+
+  * `:strict` - if `true`, then `apply/3` will raise an error if the caller provides params that are not defined in `Composite.param/4`.
+  Defaults to `false`.
   """
   @spec new([new_option]) :: t(any())
   def new(opts \\ []) do

--- a/lib/composite.ex
+++ b/lib/composite.ex
@@ -258,7 +258,8 @@ defmodule Composite do
       composite
       |> set_once!(:input_query, input_query)
       |> set_once!(:params, params)
-      |> maybe_raise_on_unknown_params()
+
+    maybe_raise_on_unknown_params(composite)
 
     {query, loaded_deps} =
       load_dependencies(
@@ -419,15 +420,15 @@ defmodule Composite do
         )
 
       case MapSet.size(diff) do
-        0 -> composite
+        0 -> :noop
         _ -> raise ArgumentError, "Unknown params: #{inspect(MapSet.to_list(diff))}"
       end
     else
-      composite
+      :noop
     end
   end
 
-  defp maybe_raise_on_unknown_params(composite), do: composite
+  defp maybe_raise_on_unknown_params(_composite), do: :noop
 
   if Code.ensure_loaded?(Ecto.Queryable) do
     defimpl Ecto.Queryable do

--- a/lib/composite.ex
+++ b/lib/composite.ex
@@ -410,8 +410,12 @@ defmodule Composite do
     if (is_map(params) and not is_struct(params)) or Keyword.keyword?(params) do
       diff =
         MapSet.difference(
-          MapSet.new(collect_keys(params)),
-          MapSet.new(composite.param_definitions |> Enum.map(&elem(&1, 0)))
+          MapSet.new(Enum.map(params, &elem(&1, 0))),
+          MapSet.new(
+            composite.param_definitions
+            |> Enum.map(&elem(&1, 0))
+            |> Enum.map(&List.first/1)
+          )
         )
 
       case MapSet.size(diff) do
@@ -424,12 +428,6 @@ defmodule Composite do
   end
 
   defp maybe_raise_on_unknown_params(composite), do: composite
-
-  defp collect_keys(data, path \\ []) do
-    Enum.flat_map(data, fn {k, v} ->
-      collect_keys(v, path ++ [k])
-    end)
-  end
 
   if Code.ensure_loaded?(Ecto.Queryable) do
     defimpl Ecto.Queryable do

--- a/lib/composite.ex
+++ b/lib/composite.ex
@@ -40,7 +40,7 @@ defmodule Composite do
           | {:on_ignore, (query -> query)}
           | {:ignore_requires, dependencies()}
   @type dependency_option :: {:requires, dependencies()}
-  @type new_option :: {:strict, boolean()}
+  @type option :: {:strict, boolean()}
   @type param_path_item :: any()
   @type apply_fun(query) :: (query, value :: any() -> query) | (query -> query)
   @type load_dependency(query) :: (query -> query) | (query, params() -> query)
@@ -77,7 +77,7 @@ defmodule Composite do
   * `:strict` - if `true`, then `apply/3` will raise an error if the caller provides params that are not defined in `Composite.param/4`.
   Defaults to `false`.
   """
-  @spec new([new_option]) :: t(any())
+  @spec new([option]) :: t(any())
   def new(opts \\ []) do
     %__MODULE__{strict: Keyword.get(opts, :strict, false)}
   end
@@ -106,7 +106,7 @@ defmodule Composite do
   * `:strict` - if `true`, then `apply/3` will raise an error if the caller provides params that are not defined in `Composite.param/4`.
   Defaults to `false`.
   """
-  @spec new(query, params(), [new_option]) :: t(query) when query: any()
+  @spec new(query, params(), [option]) :: t(query) when query: any()
   def new(input_query, params, opts \\ []) do
     %__MODULE__{
       params: params,

--- a/test/composite_test.exs
+++ b/test/composite_test.exs
@@ -222,6 +222,29 @@ defmodule CompositeTest do
     end
   end
 
+  test "unknown params when strict option is true" do
+    composite =
+      [strict: true]
+      |> Composite.new()
+      |> Composite.param(:name, &Map.put(&1, :name, &2))
+      |> Composite.param([:company, :name], &Map.put(&1, :company_name, &2))
+      |> Composite.param([:company, :type], &Map.put(&1, :company_type, &2))
+
+    assert_raise ArgumentError,
+                 "Unknown parameters found under the following paths: [:company, :service]",
+                 fn ->
+                   Composite.apply(%{}, composite, %{company: %{name: "Pear", service: "IT"}})
+                 end
+
+    assert_raise ArgumentError,
+                 "Unknown parameters found under the following paths: [:companies]",
+                 fn -> Composite.apply(%{}, composite, %{companies: %{}}) end
+
+    assert_raise ArgumentError,
+                 "Unknown parameters found under the following paths: [:names]",
+                 fn -> Composite.apply(%{}, composite, %{names: %{}}) end
+  end
+
   test "recursively apply Ecto.Queryable.to_query to input query" do
     assert "users"
            |> Composite.new(%{})


### PR DESCRIPTION
### Proposal:
Add optional param `:strict`, when true validates that the passed params by the caller are actually defined in the param definitions of the composite object.

To avoid breaking changes, the new option defaults to false.

### Current behavior:

Calling the following function:
```elixir
User
|> from(as: :user)
|> Composite.new(%{email: ["ABC", "def"]})
|> Composite.param(:emails, &filter_by_emails/2)
|> Composite.apply()
|> Repo.all()
```

Returns all the available users in the DB without any warning because the param is defined as `:emails` instead of `:email`.

### After the change 
Calling the function as:

```elixir
User
|> from(as: :user)
|> Composite.new(%{email: ["ABC", "def"]}, strict: true)
|> Composite.param(:emails, &filter_by_emails/2)
|> Composite.apply()
|> Repo.all()
```

Raises the error
```elixir
** (ArgumentError) Unknown params: [:email]
    (composite 0.4.3) lib/composite.ex:403: Composite.maybe_raise_on_unknown_params/1
    (composite 0.4.3) lib/composite.ex:246: Composite.apply/3
```

If the `:strict` option is passed as `false` or not passed at all, the behavior is the same as before the change