### PR TITLE
chore: configurable default empty values for option `ignore?`

### DIFF
--- a/lib/composite.ex
+++ b/lib/composite.ex
@@ -182,7 +182,7 @@ defmodule Composite do
   ### Options
 
   * `:ignore?` - if function returns `true`, then handler `t:apply_fun/1` won't be applied.
-  Default value is `composite.ignore?`, which can be customized via the `:ignore?` option when creating the composite.
+  Default value is set by `:ignore?` option when creating the composite.
   * `:on_ignore` - a function that will be applied instead of `t:apply_fun/1` if value is ignored.
   Defaults to `Function.identity/1`.
   * `:requires` - points to the dependencies which has to be loaded before calling `t:apply_fun/1`.

--- a/lib/composite.ex
+++ b/lib/composite.ex
@@ -69,7 +69,9 @@ defmodule Composite do
         }
 
   @doc """
-  Default empty value function. Returns `true` if the value is `nil`, `""`, `[]`, or `%{}`.
+  Default ignore function.
+
+  Returns `true` if the value is `nil`, `""`, `[]`, or `%{}`.
   """
   @spec default_ignore?(any()) :: boolean()
   def default_ignore?(value) do

--- a/lib/composite.ex
+++ b/lib/composite.ex
@@ -99,8 +99,8 @@ defmodule Composite do
 
   * `:strict` - if `true`, then `apply/3` will raise an error if the caller provides params that are not defined in `Composite.param/4`.
   Defaults to `false`.
-  * `:ignore?` - a function that determines if a value should be considered "empty" and ignored by default when no explicit `:ignore?` option is provided in `param/4`.
-  Defaults to `&Composite.default_ignore?/1` which checks if the value is in `[nil, "", [], %{}]`.
+  * `:ignore?` - a function that determines the default behaviour of `:ignore?` option in `param/4`.
+  Defaults to `&Composite.default_ignore?/1`.
   """
   @spec new([option]) :: t(any())
   def new(opts \\ []) do

--- a/lib/composite.ex
+++ b/lib/composite.ex
@@ -71,6 +71,7 @@ defmodule Composite do
   @doc """
   Default empty value function. Returns `true` if the value is `nil`, `""`, `[]`, or `%{}`.
   """
+  @spec default_ignore?(any()) :: boolean()
   def default_ignore?(value) do
     value in [nil, "", [], %{}]
   end

--- a/lib/composite.ex
+++ b/lib/composite.ex
@@ -133,8 +133,8 @@ defmodule Composite do
 
   * `:strict` - if `true`, then `apply/3` will raise an error if the caller provides params that are not defined in `Composite.param/4`.
   Defaults to `false`.
-  * `:ignore?` - a function that determines if a value should be considered "empty" and ignored by default when no explicit `:ignore?` option is provided in `param/4`.
-  Defaults to `&Composite.default_ignore?/1` which checks if the value is in `[nil, "", [], %{}]`.
+  * `:ignore?` - a function that determines the default behaviour of `:ignore?` option in `param/4`.
+  Defaults to `&Composite.default_ignore?/1`.
   """
   @spec new(query, params(), [option]) :: t(query) when query: any()
   def new(input_query, params, opts \\ []) do

--- a/test/composite_test.exs
+++ b/test/composite_test.exs
@@ -255,19 +255,20 @@ defmodule CompositeTest do
 
   test "new/1 with empty_values option" do
     composite = Composite.new(empty_values: [nil, "EMPTY"])
-    
+
     assert composite.empty_values == [nil, "EMPTY"]
-    
+
     # Test that the default ignore? behavior uses the custom empty_values
     params = %{search: "EMPTY", filter: nil, name: "John"}
-    
-    query = %{base: true}
-    |> Composite.new(params, empty_values: [nil, "EMPTY"])
-    |> Composite.param(:search, fn query, _value -> Map.put(query, :search_applied, true) end)
-    |> Composite.param(:filter, fn query, _value -> Map.put(query, :filter_applied, true) end)
-    |> Composite.param(:name, fn query, _value -> Map.put(query, :name_applied, true) end)
-    |> Composite.apply()
-    
+
+    query =
+      %{base: true}
+      |> Composite.new(params, empty_values: [nil, "EMPTY"])
+      |> Composite.param(:search, fn query, _value -> Map.put(query, :search_applied, true) end)
+      |> Composite.param(:filter, fn query, _value -> Map.put(query, :filter_applied, true) end)
+      |> Composite.param(:name, fn query, _value -> Map.put(query, :name_applied, true) end)
+      |> Composite.apply()
+
     # search and filter should be ignored (they're in empty_values)
     # name should be applied (it's not in empty_values)
     assert Map.get(query, :search_applied) == nil
@@ -278,19 +279,20 @@ defmodule CompositeTest do
 
   test "default empty_values behavior" do
     composite = Composite.new()
-    
+
     # Should use the default empty_values
     assert composite.empty_values == [nil, "", [], %{}]
-    
+
     params = %{search: "", filter: [], name: "John"}
-    
-    query = %{base: true}
-    |> Composite.new(params)
-    |> Composite.param(:search, fn query, _value -> Map.put(query, :search_applied, true) end)
-    |> Composite.param(:filter, fn query, _value -> Map.put(query, :filter_applied, true) end)
-    |> Composite.param(:name, fn query, _value -> Map.put(query, :name_applied, true) end)
-    |> Composite.apply()
-    
+
+    query =
+      %{base: true}
+      |> Composite.new(params)
+      |> Composite.param(:search, fn query, _value -> Map.put(query, :search_applied, true) end)
+      |> Composite.param(:filter, fn query, _value -> Map.put(query, :filter_applied, true) end)
+      |> Composite.param(:name, fn query, _value -> Map.put(query, :name_applied, true) end)
+      |> Composite.apply()
+
     # search and filter should be ignored (they're in default empty_values)
     # name should be applied (it's not in empty_values)
     assert Map.get(query, :search_applied) == nil

--- a/test/composite_test.exs
+++ b/test/composite_test.exs
@@ -294,10 +294,7 @@ defmodule CompositeTest do
       |> Composite.param(:name, fn query, _value -> Map.put(query, :name_applied, true) end)
       |> Composite.apply()
 
-    assert Map.get(query, :search_applied) == nil
-    assert Map.get(query, :filter_applied) == nil
-    assert query.name_applied == true
-    assert query.base == true
+    assert query == %{name_applied: true, base: true}
   end
 
   test "ignore? with operations" do

--- a/test/composite_test.exs
+++ b/test/composite_test.exs
@@ -253,19 +253,19 @@ defmodule CompositeTest do
            |> inspect() == inspect(from(users in "users"))
   end
 
-  test "new/1 with empty_value? option" do
-    composite = Composite.new(empty_value?: &(&1 in [nil, "EMPTY"]))
+  test "new/1 with ignore? option" do
+    composite = Composite.new(ignore?: &(&1 in [nil, "EMPTY"]))
 
-    assert is_function(composite.empty_value?, 1)
-    assert composite.empty_value?.(nil) == true
-    assert composite.empty_value?.("EMPTY") == true
-    assert composite.empty_value?.("John") == false
+    assert is_function(composite.ignore?, 1)
+    assert composite.ignore?.(nil) == true
+    assert composite.ignore?.("EMPTY") == true
+    assert composite.ignore?.("John") == false
 
     params = %{search: "EMPTY", filter: nil, name: "John"}
 
     query =
       %{base: true}
-      |> Composite.new(params, empty_value?: &(&1 in [nil, "EMPTY"]))
+      |> Composite.new(params, ignore?: &(&1 in [nil, "EMPTY"]))
       |> Composite.param(:search, fn query, _value -> Map.put(query, :search_applied, true) end)
       |> Composite.param(:filter, fn query, _value -> Map.put(query, :filter_applied, true) end)
       |> Composite.param(:name, fn query, _value -> Map.put(query, :name_applied, true) end)
@@ -277,15 +277,15 @@ defmodule CompositeTest do
     assert query.base == true
   end
 
-  test "default empty_value? behavior" do
+  test "default ignore? behavior" do
     composite = Composite.new()
 
-    assert is_function(composite.empty_value?, 1)
-    assert composite.empty_value?.(nil) == true
-    assert composite.empty_value?.("") == true
-    assert composite.empty_value?.([]) == true
-    assert composite.empty_value?.(%{}) == true
-    assert composite.empty_value?.("John") == false
+    assert is_function(composite.ignore?, 1)
+    assert composite.ignore?.(nil) == true
+    assert composite.ignore?.("") == true
+    assert composite.ignore?.([]) == true
+    assert composite.ignore?.(%{}) == true
+    assert composite.ignore?.("John") == false
 
     params = %{search: "", filter: [], name: "John"}
 
@@ -303,13 +303,13 @@ defmodule CompositeTest do
     assert query.base == true
   end
 
-  test "empty_value? with operations" do
+  test "ignore? with operations" do
     params = %{search: " \t ", min_age: 0, max_length: -1, user_ids: []}
 
     query =
       %{base: true}
       |> Composite.new(params,
-        empty_value?: fn
+        ignore?: fn
           value when is_binary(value) -> String.trim(value) == ""
           value when is_number(value) -> value <= 0
           value when is_list(value) -> value == []
@@ -326,10 +326,6 @@ defmodule CompositeTest do
       end)
       |> Composite.apply()
 
-    assert Map.get(query, :search_applied) == nil
-    assert Map.get(query, :min_age_applied) == nil
-    assert Map.get(query, :max_length_applied) == nil
-    assert Map.get(query, :user_ids_applied) == nil
-    assert query.base == true
+    assert query == %{base: true}
   end
 end

--- a/test/composite_test.exs
+++ b/test/composite_test.exs
@@ -271,10 +271,7 @@ defmodule CompositeTest do
       |> Composite.param(:name, fn query, _value -> Map.put(query, :name_applied, true) end)
       |> Composite.apply()
 
-    assert Map.get(query, :search_applied) == nil
-    assert Map.get(query, :filter_applied) == nil
-    assert query.name_applied == true
-    assert query.base == true
+    assert query == %{name_applied: true, base: true}
   end
 
   test "default ignore? behavior" do


### PR DESCRIPTION
### Proposal
Add optional `param :empty_values` to customize which values are considered "empty" and automatically ignored by default when no explicit `:ignore?` option is provided in `param/4`. This allows callers to override the default empty value detection behavior without needing to specify `:ignore?` on every parameter.
To avoid breaking changes, the new option defaults to `[nil, "", [], %{}]`, maintaining the current behavior.

### Current behavior
Calling the following function:
```elixir
User
|> from(as: :user)
|> Composite.new(%{search: "", filter: nil})
|> Composite.param(:search, &where(&1, [user], ilike(user.name, ^&2)))
|> Composite.param(:filter, &where(&1, [user], user.active == ^&2))
|> Composite.apply()
|> Repo.all()
```

Returns all available users because empty strings `""` and `nil` values are treated as ignored values by default, so the parameter handlers are not applied.

### After the change
Calling the function as:

```elixir
User
|> from(as: :user)
|> Composite.new(%{search: "", filter: nil}, empty_values: [nil])
|> Composite.param(:search, &where(&1, [user], ilike(user.name, ^&2)))
|> Composite.param(:filter, &where(&1, [user], user.active == ^&2))
|> Composite.apply()
|> Repo.all()
```

Now only `nil` values are ignored by default. Empty strings `""` will trigger the search parameter handler, allowing for more granular control over what constitutes an "empty" value.


If the `:empty_values` option is not passed, the behavior is identical to before the change, ensuring full backward compatibility.
